### PR TITLE
Fix capitalization in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ Here is how a file looks for example:
 	#base "../_jofrehud/resource/clientscheme.res"
 	#base "../_tf2hud/resource/clientscheme.res"
   
-As well, you can grab all the optimization files that you may find neccesary. bUt please give credit.
+As well, you can grab all the optimization files that you may find neccesary. But please give credit.
 
 ## Need help on something?
 Here is my steam profile if you need any extra help or something!


### PR DESCRIPTION
Just fixed a typo that really bugged me for some reason. Grammar wise, that sentence probably should be rewritten, but i'll leave that to you.